### PR TITLE
fix(ci): restore Android builds without signing secrets

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build Signed APK
     runs-on: ubuntu-latest
+    env:
+      KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
 
     steps:
     - name: Checkout Repository
@@ -25,14 +27,14 @@ jobs:
         cache: gradle
 
     - name: Decode Keystore
-      if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+      if: ${{ env.KEYSTORE_BASE64 != '' }}
       env:
-        ENCODED_KEYSTORE: ${{ secrets.KEYSTORE_BASE64 }}
+        ENCODED_KEYSTORE: ${{ env.KEYSTORE_BASE64 }}
       run: |
         echo $ENCODED_KEYSTORE | base64 -di > keystore.jks
 
     - name: Build Release APK
-      if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+      if: ${{ env.KEYSTORE_BASE64 != '' }}
       env:
         SIGNING_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
         SIGNING_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
@@ -46,8 +48,12 @@ jobs:
           -Pandroid.injected.signing.key.password=$SIGNING_KEY_PASSWORD
 
     - name: Build Debug APK (fork PR fallback without signing)
-      if: ${{ secrets.KEYSTORE_BASE64 == '' }}
+      if: ${{ env.KEYSTORE_BASE64 == '' }}
       run: |
+        mkdir -p "$HOME/.android"
+        keytool -genkeypair -keystore "$HOME/.android/debug.keystore" \
+          -storepass android -alias androiddebugkey -keypass android \
+          -dname "CN=Android Debug,O=Android,C=US" -keyalg RSA -validity 10000
         chmod +x gradlew
         ./gradlew assembleUniversalFossDebug
 


### PR DESCRIPTION
## What changed

GitHub rejects direct `secrets` references in step `if` expressions, so the Android workflow failed validation before creating a job. This maps `KEYSTORE_BASE64` through job `env` and checks that value instead.

The unsigned fork fallback also creates the standard debug keystore before building; clean runners do not have one yet.

Broken run: https://github.com/EchoMusicApp/Echo-Music/actions/runs/33830176682

## Testing

Fork Actions run: https://github.com/mishalshanavas/Echo-Music/actions/runs/33832001682

`Build Signed APK` passed and uploaded the universal FOSS debug APK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build automation to consistently handle the keystore configuration.
  * Added a fallback that generates a debug keystore when no release keystore is available.
  * Release and debug APK builds now use the appropriate keystore path based on the available configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->