### PR TITLE
fix(ci): bootstrap debug keystore on clean runners

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -47,6 +47,15 @@ jobs:
       env:
         KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
       run: |
+        mkdir -p "$HOME/.android"
+        keytool -genkeypair \
+          -keystore "$HOME/.android/debug.keystore" \
+          -storepass android \
+          -alias androiddebugkey \
+          -keypass android \
+          -dname "CN=Android Debug,O=Android,C=US" \
+          -keyalg RSA \
+          -validity 10000
         chmod +x gradlew
         ./gradlew assembleUniversalFossDebug
 


### PR DESCRIPTION
## Problem

GitHub-hosted runners start with a clean home directory — `$HOME/.android/debug.keystore` does not exist. The fork/PR fallback build step (**Build Debug APK**) was failing because the Android Gradle Plugin looks for this file when no release signing config is provided and exits with a keystore-not-found error before any compilation begins.

This silently blocked every contributor and fork from getting a passing CI build.

## Fix

Generate a standard Android debug keystore via `keytool` before invoking Gradle. Uses the canonical Android debug defaults so the produced APK is signed identically to a local developer machine:

| Parameter | Value |
|-----------|-------|
| Alias | `androiddebugkey` |
| Store password | `android` |
| Key password | `android` |
| Algorithm | RSA |
| Validity | 10 000 days |

```yaml
mkdir -p "$HOME/.android"
keytool -genkeypair \
  -keystore "$HOME/.android/debug.keystore" \
  -storepass android \
  -alias androiddebugkey \
  -keypass android \
  -dname "CN=Android Debug,O=Android,C=US" \
  -keyalg RSA \
  -validity 10000
```

## Security

Secrets remain **step-scoped** (unchanged from `main`). `KEYSTORE_BASE64` and all other release signing credentials are **not** exposed at the job level, so PR branch code cannot access them. This deliberately avoids the job-level `env:` approach flagged by CodeRabbit in PR #290 (CWE-200).

## Testing

The fix is self-contained and only touches the CI fallback path that runs when `KEYSTORE_BASE64` is empty (i.e., forks and contributor PRs). The signed release build path is completely unchanged.

## Related

- Addresses the root cause behind the fork CI failures noted in PR #290
- Supersedes PR #290 (which solved the `secrets.*` in `if:` problem — already merged — but did not include the keystore bootstrap and introduced a job-level secret exposure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved debug Android build reliability by generating a local signing key when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->