### PR TITLE
feat(export): show export progress and fix stale state after backup restore (fixes #287)

### DIFF
--- a/app/src/main/kotlin/com/music/echo/MainActivity.kt
+++ b/app/src/main/kotlin/com/music/echo/MainActivity.kt
@@ -380,6 +380,17 @@ class MainActivity : ComponentActivity() {
             setAppLocale(this, locale)
         }
 
+        if (java.io.File(filesDir, "clear_export_state").exists()) {
+            lifecycleScope.launch {
+                dataStore.edit { preferences ->
+                    preferences.remove(echo.music.iad1tya.constants.ExportingSongIdsKey)
+                    preferences.remove(echo.music.iad1tya.constants.ExportedSongIdsKey)
+                    preferences.remove(echo.music.iad1tya.constants.ExportProgressKey)
+                }
+                java.io.File(filesDir, "clear_export_state").delete()
+            }
+        }
+
         lifecycleScope.launch {
             dataStore.data
                 .map { (try { it[DisableScreenshotKey] } catch(e: Exception) { null }) ?: false }

--- a/app/src/main/kotlin/com/music/echo/playback/AudioExportService.kt
+++ b/app/src/main/kotlin/com/music/echo/playback/AudioExportService.kt
@@ -14,6 +14,7 @@ import com.music.innertube.YouTube
 import echo.music.iad1tya.constants.AudioQuality
 import echo.music.iad1tya.constants.ExportingSongIdsKey
 import echo.music.iad1tya.constants.ExportedSongIdsKey
+import echo.music.iad1tya.constants.ExportProgressKey
 import echo.music.iad1tya.utils.YTPlayerUtils
 import echo.music.iad1tya.utils.dataStore
 import androidx.datastore.preferences.core.edit
@@ -77,7 +78,9 @@ class AudioExportService : Service() {
             ).getOrThrow()
 
             val year = fetchSongYear(songId)
-            downloadStream(playbackData, tempSourceFile)
+            downloadStream(playbackData, tempSourceFile) { percent ->
+                updateExportProgress(songId, percent)
+            }
             val artworkDownloaded = downloadArtwork(artworkUrl, tempArtworkFile)
             convertToMp3(
                 sourceFile = tempSourceFile,
@@ -97,6 +100,7 @@ class AudioExportService : Service() {
             tempSourceFile.delete()
             tempArtworkFile.delete()
             tempMp3File.delete()
+            clearExportProgress(songId)
             removeExportingSongId(songId)
             stopSelf()
         }
@@ -110,17 +114,19 @@ class AudioExportService : Service() {
     private fun downloadStream(
         playbackData: echo.music.iad1tya.utils.YTPlayerUtils.PlaybackData,
         destFile: File,
+        onProgress: suspend (Int) -> Unit = {},
     ) {
         val totalLength = playbackData.format.contentLength ?: 10_000_000L
         val rangedUrl = "${playbackData.streamUrl}&range=0-$totalLength"
         val request = Request.Builder().url(rangedUrl).build()
         var totalBytes = -1L
         var bytesWritten = 0L
+        var lastReportedPercent = -1
 
         httpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) error("Stream request failed with ${response.code}")
             val body = response.body ?: error("No response body")
-            totalBytes = body.contentLength()
+            totalBytes = body.contentLength().takeIf { it > 0 } ?: totalLength
             val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
             body.byteStream().use { input ->
                 destFile.outputStream().use { output ->
@@ -128,6 +134,11 @@ class AudioExportService : Service() {
                     while (input.read(buffer).also { read = it } != -1) {
                         output.write(buffer, 0, read)
                         bytesWritten += read
+                        val percent = ((bytesWritten * 100) / totalBytes).toInt().coerceIn(0, 99)
+                        if (percent >= lastReportedPercent + 2) {
+                            lastReportedPercent = percent
+                            kotlinx.coroutines.runBlocking { onProgress(percent) }
+                        }
                     }
                     output.flush()
                 }
@@ -238,6 +249,34 @@ class AudioExportService : Service() {
                 .map { it.trim() }
                 .filter { it.isNotBlank() }
             preferences[ExportingSongIdsKey] = current.filterNot { it == songId }.joinToString(",")
+        }
+    }
+
+    private suspend fun updateExportProgress(songId: String, percent: Int) {
+        dataStore.edit { preferences ->
+            val current = preferences[ExportProgressKey].orEmpty()
+                .split(',')
+                .filter { it.isNotBlank() }
+                .associate { 
+                    val parts = it.split(':')
+                    parts[0] to (parts.getOrNull(1)?.toIntOrNull() ?: 0)
+                }.toMutableMap()
+            current[songId] = percent
+            preferences[ExportProgressKey] = current.map { "${it.key}:${it.value}" }.joinToString(",")
+        }
+    }
+
+    private suspend fun clearExportProgress(songId: String) {
+        dataStore.edit { preferences ->
+            val current = preferences[ExportProgressKey].orEmpty()
+                .split(',')
+                .filter { it.isNotBlank() }
+                .associate { 
+                    val parts = it.split(':')
+                    parts[0] to (parts.getOrNull(1)?.toIntOrNull() ?: 0)
+                }.toMutableMap()
+            current.remove(songId)
+            preferences[ExportProgressKey] = current.map { "${it.key}:${it.value}" }.joinToString(",")
         }
     }
 

--- a/app/src/main/kotlin/com/music/echo/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/menu/SongMenu.kt
@@ -127,9 +127,13 @@ fun SongMenu(
     val (exportDirectoryUri) = rememberPreference(key = ExportDirectoryUriKey, defaultValue = "")
     val (exportingSongIds) = rememberPreference(key = ExportingSongIdsKey, defaultValue = "")
     val (exportedSongIds) = rememberPreference(key = ExportedSongIdsKey, defaultValue = "")
+    val (exportProgressRaw) = rememberPreference(key = echo.music.iad1tya.constants.ExportProgressKey, defaultValue = "")
 
     val isExporting = remember(exportingSongIds, song.id) { exportingSongIds.split(",").contains(song.id) }
     val isExported = remember(exportedSongIds, song.id) { exportedSongIds.split(",").contains(song.id) }
+    val exportProgress = remember(exportProgressRaw, song.id) {
+        exportProgressRaw.split(",").find { it.startsWith("${song.id}:") }?.substringAfter(":")?.toIntOrNull()
+    }
 
     var refetchIconDegree by remember { mutableFloatStateOf(0f) }
 
@@ -724,11 +728,15 @@ fun SongMenu(
                     items = listOf(
                         when {
                             isExporting -> Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.exporting)) },
+                                title = { 
+                                    val text = stringResource(R.string.exporting)
+                                    Text(text = if (exportProgress != null) "$text • $exportProgress%" else text) 
+                                },
                                 icon = {
                                     CircularProgressIndicator(
                                         modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp
+                                        strokeWidth = 2.dp,
+                                        progress = { if (exportProgress != null) exportProgress / 100f else 0f }
                                     )
                                 },
                                 onClick = {}

--- a/app/src/main/kotlin/com/music/echo/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/music/echo/viewmodels/BackupRestoreViewModel.kt
@@ -102,6 +102,7 @@ class BackupRestoreViewModel @Inject constructor(
                                     .use { outputStream ->
                                         inputStream.copyTo(outputStream)
                                     }
+                                java.io.File(context.filesDir, "clear_export_state").createNewFile()
                             }
                             InternalDatabase.DB_NAME -> {
                                 Timber.tag("RESTORE").i("Restoring DB (entry = ${entry.name})")

--- a/core/src/main/kotlin/echo/music/iad1tya/constants/PreferenceKeys.kt
+++ b/core/src/main/kotlin/echo/music/iad1tya/constants/PreferenceKeys.kt
@@ -152,6 +152,8 @@ val MaxSongCacheSizeKey = intPreferencesKey("maxSongCacheSize")
 val ExportDirectoryUriKey = stringPreferencesKey("exportDirectoryUri")
 val ExportingSongIdsKey = stringPreferencesKey("exportingSongIds")
 val ExportedSongIdsKey = stringPreferencesKey("exportedSongIds")
+// Comma-separated "songId:percent" pairs, e.g. "abc:42,def:87"
+val ExportProgressKey = stringPreferencesKey("exportProgress")
 val EnableExportAsMp3Key = booleanPreferencesKey("enableExportAsMp3")
 
 val PauseListenHistoryKey = booleanPreferencesKey("pauseListenHistory")


### PR DESCRIPTION
## Summary

Fixes the issues reported in #287 regarding audio exports.

1. **Live Progress Reporting:**
   - Instead of a static loading icon, the song menu now displays the live download progress percentage (e.g., `Exporting • 45%`).
   - Integrated progress tracking via a new `ExportProgressKey` datastore tracking down to the stream byte transfer in `AudioExportService`.

2. **Stale State Cleanup After Restore:**
   - Previously, restoring a backup on a new device would falsely flag songs as "Exported" because the old Datastore settings came with the backup, even though the physical MP3 files weren't brought over.
   - Now, `BackupRestoreViewModel` leaves a marker during the restore process. On the first launch after a restore, `MainActivity` will detect this and wipe the stale export tracking keys (`ExportedSongIdsKey`, `ExportingSongIdsKey`, and `ExportProgressKey`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-song export progress tracking.
  * Export progress is now displayed as a percentage with a circular progress indicator in the song menu.

* **Bug Fixes**
  * Restoring a backup now clears stale export state, preventing outdated export information from persisting after restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->