### PR TITLE
fix(theme): remove saturation and lightness sliders from color picker

### DIFF
--- a/app/src/main/kotlin/com/music/echo/ui/screens/settings/ThemeScreen.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/screens/settings/ThemeScreen.kt
@@ -435,32 +435,6 @@ fun HsvColorPicker(
                 )
             )
         )
-        CustomColorSlider(
-            value = saturation,
-            onValueChange = { saturation = it },
-            onValueChangeFinished = { commitColor() },
-            valueRange = 0f..1f,
-            label = "Saturation",
-            brush = Brush.horizontalGradient(
-                colors = listOf(
-                    Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, 0f, value))),
-                    Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, 1f, value)))
-                )
-            )
-        )
-        CustomColorSlider(
-            value = value,
-            onValueChange = { value = it },
-            onValueChangeFinished = { commitColor() },
-            valueRange = 0f..1f,
-            label = "Lightness",
-            brush = Brush.horizontalGradient(
-                colors = listOf(
-                    Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, saturation, 0f))),
-                    Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, saturation, 1f)))
-                )
-            )
-        )
     }
 }
 
@@ -495,7 +469,7 @@ fun CustomColorSlider(
                 onValueChangeFinished = onValueChangeFinished,
                 valueRange = valueRange,
                 colors = SliderDefaults.colors(
-                    thumbColor = MaterialTheme.colorScheme.surface,
+                    thumbColor = Color.White,
                     activeTrackColor = Color.Transparent,
                     inactiveTrackColor = Color.Transparent,
                 ),


### PR DESCRIPTION
## Summary

This PR simplifies the custom theme color picker in the settings by removing the Saturation and Lightness sliders, leaving only the Hue slider. 

**Reasoning:**
Users were frequently running into issues (like #292) where moving the brightness/saturation sliders to 0 would cause the sliders to render entirely black or invisible, making them think the app was broken. Removing them streamlines the customization process and prevents users from selecting completely black or white accent colors that clash with the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The theme color picker now displays only a Hue slider.
  * Slider thumbs now appear in white for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->