### PR TITLE
Fix wrong-song playback index, missing notification controls, and playlist reorder after backup import

### DIFF
--- a/app/src/main/kotlin/com/music/echo/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/music/echo/playback/MediaLibrarySessionCallback.kt
@@ -71,31 +71,54 @@ constructor(
     var toggleLibrary: () -> Unit = {}
 
     /**
+     * Whether [controller] is a surface allowed to mutate playback state via the toggle
+     * custom commands (like/library/shuffle/repeat/radio): a trusted controller (the app
+     * itself, systemui, or an app holding MEDIA_CONTENT_CONTROL / an enabled notification
+     * listener), the system media notification, Android Auto, or an Auto companion app.
+     * [MusicService] is an exported [MediaLibraryService][androidx.media3.session.MediaLibraryService],
+     * so without this check any app on the device could bind to the session and invoke
+     * these state-changing commands.
+     */
+    private fun isAuthorizedController(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+    ): Boolean =
+        controller.isTrusted ||
+            session.isMediaNotificationController(controller) ||
+            session.isAutomotiveController(controller) ||
+            session.isAutoCompanionController(controller)
+
+    /**
      * Negotiates connection capabilities for an incoming controller.
      *
      * Exposes the toggle custom commands ([SessionCommand]s for like, start-radio, library,
-     * shuffle and repeat) to every controller — the system notification / mini player, the
-     * lock screen, Wear, and Android Auto all drive playback exclusively through these
-     * commands, so gating them to specific automotive package names hides the buttons
-     * everywhere else.
+     * shuffle and repeat) only to [isAuthorizedController] controllers — the system
+     * notification / mini player, the lock screen, Wear, and Android Auto all drive playback
+     * exclusively through these commands, so they still need to reach those surfaces, but an
+     * arbitrary unauthorized app must not be able to invoke them.
      *
      * @param session the media session receiving the connection
      * @param controller the connecting controller
-     * @return accepted [MediaSession.ConnectionResult] with the toggle commands added
+     * @return accepted [MediaSession.ConnectionResult] with the toggle commands added for
+     *   authorized controllers
      */
     override fun onConnect(
         session: MediaSession,
         controller: MediaSession.ControllerInfo,
     ): MediaSession.ConnectionResult {
         val connectionResult = super.onConnect(session, controller)
-        val availableSessionCommands = connectionResult.availableSessionCommands
-            .buildUpon()
-            .add(MediaSessionConstants.CommandToggleLike)
-            .add(MediaSessionConstants.CommandToggleStartRadio)
-            .add(MediaSessionConstants.CommandToggleLibrary)
-            .add(MediaSessionConstants.CommandToggleShuffle)
-            .add(MediaSessionConstants.CommandToggleRepeatMode)
-            .build()
+        val availableSessionCommands = if (isAuthorizedController(session, controller)) {
+            connectionResult.availableSessionCommands
+                .buildUpon()
+                .add(MediaSessionConstants.CommandToggleLike)
+                .add(MediaSessionConstants.CommandToggleStartRadio)
+                .add(MediaSessionConstants.CommandToggleLibrary)
+                .add(MediaSessionConstants.CommandToggleShuffle)
+                .add(MediaSessionConstants.CommandToggleRepeatMode)
+                .build()
+        } else {
+            connectionResult.availableSessionCommands
+        }
 
         return MediaSession.ConnectionResult.accept(
             availableSessionCommands,
@@ -105,6 +128,10 @@ constructor(
 
     /**
      * Handles custom session commands such as toggle-like, toggle-shuffle and toggle-repeat.
+     *
+     * Toggle commands are re-checked against [isAuthorizedController] as defense in depth —
+     * [onConnect] should already keep them out of an unauthorized controller's
+     * available-commands set, but a controller that somehow still sends one is rejected here.
      *
      * @param session the host [MediaSession]
      * @param controller the controller that sent the command
@@ -118,6 +145,14 @@ constructor(
         customCommand: SessionCommand,
         args: Bundle,
     ): ListenableFuture<SessionResult> {
+        val isToggleCommand = customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_LIKE ||
+            customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_START_RADIO ||
+            customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_LIBRARY ||
+            customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_SHUFFLE ||
+            customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_REPEAT_MODE
+        if (isToggleCommand && !isAuthorizedController(session, controller)) {
+            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_PERMISSION_DENIED))
+        }
         when (customCommand.customAction) {
             MediaSessionConstants.ACTION_TOGGLE_LIKE -> toggleLike()
             MediaSessionConstants.ACTION_TOGGLE_START_RADIO -> toggleStartRadio()

--- a/app/src/main/kotlin/com/music/echo/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/music/echo/playback/MediaLibrarySessionCallback.kt
@@ -73,36 +73,29 @@ constructor(
     /**
      * Negotiates connection capabilities for an incoming controller.
      *
-     * Exposes toggle custom commands ([SessionCommand]s for like, start-radio, library,
-     * shuffle and repeat) only to automotive controllers (Android Auto / Automotive OS:
-     * `com.google.android.projection.gearhead`, `com.google.android.gms.car`,
-     * `com.android.systemui`). Non-automotive controllers receive the default
-     * [MediaSession.ConnectionResult.availableSessionCommands] unchanged.
+     * Exposes the toggle custom commands ([SessionCommand]s for like, start-radio, library,
+     * shuffle and repeat) to every controller — the system notification / mini player, the
+     * lock screen, Wear, and Android Auto all drive playback exclusively through these
+     * commands, so gating them to specific automotive package names hides the buttons
+     * everywhere else.
      *
      * @param session the media session receiving the connection
-     * @param controller the connecting controller, inspected via [MediaSession.ControllerInfo.packageName]
-     * @return accepted [MediaSession.ConnectionResult] with filtered [MediaSession.ConnectionResult.availableSessionCommands]
+     * @param controller the connecting controller
+     * @return accepted [MediaSession.ConnectionResult] with the toggle commands added
      */
     override fun onConnect(
         session: MediaSession,
         controller: MediaSession.ControllerInfo,
     ): MediaSession.ConnectionResult {
         val connectionResult = super.onConnect(session, controller)
-        val isAutomotive = controller.packageName == "com.google.android.projection.gearhead" ||
-                           controller.packageName == "com.google.android.gms.car" ||
-                           controller.packageName == "com.android.systemui"
-        val availableSessionCommands = if (isAutomotive) {
-            connectionResult.availableSessionCommands
-                .buildUpon()
-                .add(MediaSessionConstants.CommandToggleLike)
-                .add(MediaSessionConstants.CommandToggleStartRadio)
-                .add(MediaSessionConstants.CommandToggleLibrary)
-                .add(MediaSessionConstants.CommandToggleShuffle)
-                .add(MediaSessionConstants.CommandToggleRepeatMode)
-                .build()
-        } else {
-            connectionResult.availableSessionCommands
-        }
+        val availableSessionCommands = connectionResult.availableSessionCommands
+            .buildUpon()
+            .add(MediaSessionConstants.CommandToggleLike)
+            .add(MediaSessionConstants.CommandToggleStartRadio)
+            .add(MediaSessionConstants.CommandToggleLibrary)
+            .add(MediaSessionConstants.CommandToggleShuffle)
+            .add(MediaSessionConstants.CommandToggleRepeatMode)
+            .build()
 
         return MediaSession.ConnectionResult.accept(
             availableSessionCommands,
@@ -112,11 +105,6 @@ constructor(
 
     /**
      * Handles custom session commands such as toggle-like, toggle-shuffle and toggle-repeat.
-     *
-     * Guarded for automotive use: toggle commands are accepted only when the caller is an
-     * automotive controller (gearhead / gms.car / systemui). Non-automotive callers receive
-     * [SessionResult.RESULT_ERROR_PERMISSION_DENIED]. Other custom actions return
-     * [SessionResult.RESULT_SUCCESS] after invoking the corresponding lambda or player mutation.
      *
      * @param session the host [MediaSession]
      * @param controller the controller that sent the command
@@ -130,17 +118,6 @@ constructor(
         customCommand: SessionCommand,
         args: Bundle,
     ): ListenableFuture<SessionResult> {
-        val isAutomotive = controller.packageName == "com.google.android.projection.gearhead" ||
-                           controller.packageName == "com.google.android.gms.car" ||
-                           controller.packageName == "com.android.systemui"
-        val isToggleCommand = customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_LIKE ||
-                customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_START_RADIO ||
-                customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_LIBRARY ||
-                customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_SHUFFLE ||
-                customCommand.customAction == MediaSessionConstants.ACTION_TOGGLE_REPEAT_MODE
-        if (isToggleCommand && !isAutomotive) {
-            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_PERMISSION_DENIED))
-        }
         when (customCommand.customAction) {
             MediaSessionConstants.ACTION_TOGGLE_LIKE -> toggleLike()
             MediaSessionConstants.ACTION_TOGGLE_START_RADIO -> toggleStartRadio()

--- a/core/src/main/kotlin/echo/music/iad1tya/db/MusicDatabase.kt
+++ b/core/src/main/kotlin/echo/music/iad1tya/db/MusicDatabase.kt
@@ -268,12 +268,14 @@ val MIGRATION_1_2 =
             }
             playlistSongMaps.sortBy { it.position }
             val playlistSongCount = mutableMapOf<String, Int>()
-            playlistSongMaps.map { map ->
+            val renumberedPlaylistSongMaps = playlistSongMaps.map { map ->
                 if (map.playlistId !in playlistSongCount) playlistSongCount[map.playlistId] = 0
                 map.copy(position = playlistSongCount[map.playlistId]!!).also {
                     playlistSongCount[map.playlistId] = playlistSongCount[map.playlistId]!! + 1
                 }
             }
+            playlistSongMaps.clear()
+            playlistSongMaps.addAll(renumberedPlaylistSongMaps)
             val songs = mutableListOf<OldSongEntity>()
             val songArtistMaps = mutableListOf<SongArtistMap>()
             db.query("SELECT * FROM song".toSQLiteQuery()).use { cursor ->

--- a/playback/src/main/kotlin/echo/music/iad1tya/playback/queues/Queue.kt
+++ b/playback/src/main/kotlin/echo/music/iad1tya/playback/queues/Queue.kt
@@ -40,10 +40,23 @@ interface Queue {
          * mediaId) after [newItems] has had entries removed, instead of leaving it as
          * a raw position into a now-shorter list — which would silently select and
          * play a different song than the one the user tapped.
+         *
+         * Matches by occurrence rather than the first same-mediaId hit, so a queue with
+         * the same song listed more than once still re-points at the exact occurrence
+         * that was selected instead of always snapping to the first one.
          */
         private fun withFilteredItems(newItems: List<MediaItem>): Status {
             val currentItem = items.getOrNull(mediaItemIndex)
-            val newIndex = currentItem?.let { item -> newItems.indexOfFirst { it.mediaId == item.mediaId } } ?: -1
+            val newIndex = if (currentItem != null) {
+                val occurrence = items.take(mediaItemIndex + 1).count { it.mediaId == currentItem.mediaId } - 1
+                newItems.withIndex()
+                    .filter { (_, item) -> item.mediaId == currentItem.mediaId }
+                    .getOrNull(occurrence)
+                    ?.index
+                    ?: -1
+            } else {
+                -1
+            }
             return copy(
                 items = newItems,
                 mediaItemIndex = if (newIndex >= 0) newIndex else mediaItemIndex.coerceIn(0, (newItems.size - 1).coerceAtLeast(0)),

--- a/playback/src/main/kotlin/echo/music/iad1tya/playback/queues/Queue.kt
+++ b/playback/src/main/kotlin/echo/music/iad1tya/playback/queues/Queue.kt
@@ -23,21 +23,32 @@ interface Queue {
     ) {
         fun filterExplicit(enabled: Boolean = true) =
             if (enabled) {
-                copy(
-                    items = items.filterExplicit(),
-                )
+                withFilteredItems(items.filterExplicit())
             } else {
                 this
             }
 
         fun filterVideoSongs(disableVideos: Boolean = false) =
             if (disableVideos) {
-                copy(
-                    items = items.filterVideoSongs(true),
-                )
+                withFilteredItems(items.filterVideoSongs(true))
             } else {
                 this
             }
+
+        /**
+         * Re-points [mediaItemIndex] at the item it originally selected (matched by
+         * mediaId) after [newItems] has had entries removed, instead of leaving it as
+         * a raw position into a now-shorter list — which would silently select and
+         * play a different song than the one the user tapped.
+         */
+        private fun withFilteredItems(newItems: List<MediaItem>): Status {
+            val currentItem = items.getOrNull(mediaItemIndex)
+            val newIndex = currentItem?.let { item -> newItems.indexOfFirst { it.mediaId == item.mediaId } } ?: -1
+            return copy(
+                items = newItems,
+                mediaItemIndex = if (newIndex >= 0) newIndex else mediaItemIndex.coerceIn(0, (newItems.size - 1).coerceAtLeast(0)),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Three independent bugs, each traced to its root cause in source and verified to compile (`:playback` and `:app` build successfully):

- **Fixes #293** — Liked Songs (and any list) plays a different song than the one tapped. `Queue.Status.filterExplicit`/`filterVideoSongs` dropped items from the queue for explicit/video-song filtering but left `mediaItemIndex` as a raw position into the now-shorter list. Any filtered item ahead of the tapped song shifted playback onto the wrong track. Fixed by re-locating the tapped item by `mediaId` after filtering instead of trusting the old index.
- **Fixes #311** — Repeat/shuffle (and like/start-radio) missing from the mini player / system notification. PR #244 (Android Auto support) gated these custom session commands behind an `isAutomotive` controller check, so only Android Auto/Automotive controllers received them — the regular phone notification lost the buttons entirely. Restored them for every connecting controller.
- **Fixes #242** — Can't reorder songs in a playlist migrated from an old backup. The legacy-schema migration renumbers each playlist's song positions into a clean `0..n-1` sequence via `.map { ... }`, but discards the result and inserts the original, non-sequential positions instead. The drag-reorder SQL assumes contiguous positions, so reordering silently did nothing for any playlist that went through this migration. Now the renumbered list is actually used.

Note: the playlist-reorder fix only affects future imports — playlists already migrated on a device would need a data-repair migration to fix retroactively, which isn't included here.

## Test plan

- [x] `./gradlew :playback:compileFossDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:compileUniversalFossDebugKotlin` — BUILD SUCCESSFUL
- [ ] Manual verification on-device (not available in this environment): tap a liked song with Data Saver enabled and confirm the right track plays; confirm shuffle/repeat appear in the notification; convert an old backup, add a song, and drag-reorder it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Playback**
  - Restricted playback toggle controls—like, radio, library, shuffle, and repeat—to trusted and supported controllers.

- **Bug Fixes**
  - Fixed playlist song positions not being renumbered correctly during database updates.
  - Preserved the currently selected queue item when filtering explicit or video content, when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->