### PR TITLE
fix(ui): parse markdown changelog properly in update dialog

### DIFF
--- a/app/src/main/kotlin/com/music/echo/echomusic/component/UpdateAvailableDialog.kt
+++ b/app/src/main/kotlin/com/music/echo/echomusic/component/UpdateAvailableDialog.kt
@@ -20,6 +20,14 @@ import echo.music.iad1tya.ui.utils.parseMarkdownToSections
 import echo.music.iad1tya.ui.utils.parseSimpleMarkdown
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 
+/**
+ * Displays a dialog informing the user that a newer version of the application is available.
+ *
+ * @param version The latest version tag or display string.
+ * @param changelog Pre-parsed structured changelog sections, if available.
+ * @param description Raw release description or fallback Markdown text.
+ * @param onDismiss Invoked when the user dismisses the dialog.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UpdateAvailableDialog(
@@ -173,11 +181,6 @@ fun UpdateAvailableDialog(
                                         }
                                     }
                                 }
-                            } else if (!description.isNullOrEmpty()) {
-                                Text(
-                                    text = parseSimpleMarkdown(description, MaterialTheme.colorScheme.primary),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/music/echo/echomusic/component/UpdateAvailableDialog.kt
+++ b/app/src/main/kotlin/com/music/echo/echomusic/component/UpdateAvailableDialog.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -15,6 +16,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import echo.music.iad1tya.R
 import echo.music.iad1tya.echomusic.updater.ChangelogSection
+import echo.music.iad1tya.ui.utils.parseMarkdownToSections
 import echo.music.iad1tya.ui.utils.parseSimpleMarkdown
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 
@@ -119,24 +121,61 @@ fun UpdateAvailableDialog(
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.primary
                             )
-                            if (changelog.isNotEmpty()) {
-                                changelog.forEach { section ->
-                                    Text(
-                                        text = section.title,
-                                        style = MaterialTheme.typography.titleSmall,
-                                        fontWeight = FontWeight.SemiBold,
-                                        modifier = Modifier.padding(top = 4.dp)
-                                    )
-                                    section.items.forEach { item ->
+
+                            val (effectiveDescription, effectiveSections) = remember(changelog, description) {
+                                if (changelog.isNotEmpty()) {
+                                    Pair(description?.takeIf { it.isNotBlank() }, changelog)
+                                } else if (!description.isNullOrBlank()) {
+                                    parseMarkdownToSections(description)
+                                } else {
+                                    Pair(null, emptyList())
+                                }
+                            }
+
+                            if (!effectiveDescription.isNullOrBlank()) {
+                                Text(
+                                    text = parseSimpleMarkdown(effectiveDescription, MaterialTheme.colorScheme.primary),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(bottom = 4.dp)
+                                )
+                            }
+
+                            if (effectiveSections.isNotEmpty()) {
+                                effectiveSections.forEach { section ->
+                                    if (section.title.isNotBlank()) {
                                         Text(
-                                            text = "• ${item.trim()}",
-                                            style = MaterialTheme.typography.bodyMedium,
+                                            text = section.title,
+                                            style = MaterialTheme.typography.titleSmall,
+                                            fontWeight = FontWeight.Bold,
+                                            color = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.padding(top = 6.dp)
                                         )
+                                    }
+                                    section.items.forEach { item ->
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(vertical = 2.dp),
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                        ) {
+                                            Text(
+                                                text = "•",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                fontWeight = FontWeight.Bold,
+                                            )
+                                            Text(
+                                                text = parseSimpleMarkdown(item.trim(), MaterialTheme.colorScheme.primary),
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                modifier = Modifier.weight(1f)
+                                            )
+                                        }
                                     }
                                 }
                             } else if (!description.isNullOrEmpty()) {
                                 Text(
-                                    text = parseSimpleMarkdown(description),
+                                    text = parseSimpleMarkdown(description, MaterialTheme.colorScheme.primary),
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
                             }

--- a/app/src/main/kotlin/com/music/echo/echomusic/updater/echomusicupdater.kt
+++ b/app/src/main/kotlin/com/music/echo/echomusic/updater/echomusicupdater.kt
@@ -93,6 +93,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.foundation.lazy.LazyColumn
+import echo.music.iad1tya.ui.utils.parseMarkdownToSections
+import echo.music.iad1tya.ui.utils.parseSimpleMarkdown
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -713,7 +715,9 @@ suspend fun checkForUpdate(
                         imageUrl = match.groupValues[2]
                         body = body.replace(match.value, "").trim()
                     }
-                    description = body
+                    val (parsedDesc, parsedSections) = parseMarkdownToSections(body)
+                    description = parsedDesc ?: body.takeIf { parsedSections.isEmpty() }
+                    changelogList.addAll(parsedSections)
                 }
 
                 val publishedAt = targetRelease.getString("published_at")
@@ -824,7 +828,9 @@ suspend fun fetchChangelogForVersion(currentVersion: String): WhatsNewInfo? = wi
             var body = release.optString("body", "")
             val imageRegex = Regex("!\\[(.*?)\\]\\((.*?)\\)")
             imageRegex.find(body)?.let { match -> body = body.replace(match.value, "").trim() }
-            description = body.takeIf { it.isNotEmpty() }
+            val (parsedDesc, parsedSections) = parseMarkdownToSections(body)
+            description = parsedDesc ?: body.takeIf { parsedSections.isEmpty() }
+            changelogList.addAll(parsedSections)
         }
 
         if (changelogList.isEmpty() && description.isNullOrBlank()) return@withContext null
@@ -850,25 +856,37 @@ fun WhatsNewDialog(
             }
         }
     ) {
+        val (effectiveDescription, effectiveSections) = remember(info) {
+            if (info.changelog.isNotEmpty()) {
+                Pair(info.description?.takeIf { it.isNotBlank() }, info.changelog)
+            } else if (!info.description.isNullOrBlank()) {
+                parseMarkdownToSections(info.description)
+            } else {
+                Pair(null, emptyList())
+            }
+        }
+
         LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
-            info.description?.takeIf { it.isNotBlank() }?.let { description ->
+            effectiveDescription?.let { description ->
                 item {
                     Text(
-                        text = description,
+                        text = parseSimpleMarkdown(description),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(bottom = 16.dp)
                     )
                 }
             }
-            info.changelog.forEach { section ->
-                item {
-                    Text(
-                        text = section.title,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
-                    )
+            effectiveSections.forEach { section ->
+                if (section.title.isNotBlank()) {
+                    item {
+                        Text(
+                            text = section.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
+                        )
+                    }
                 }
                 itemsIndexed(section.items) { index, changelogItem ->
                     val shape = when {

--- a/app/src/main/kotlin/com/music/echo/ui/component/UpdaterComponents.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/component/UpdaterComponents.kt
@@ -252,6 +252,13 @@ fun String.parseMarkdown(): androidx.compose.ui.text.AnnotatedString {
     return builder.toAnnotatedString()
 }
 
+/**
+ * Renders an individual changelog entry inside a styled container surface.
+ *
+ * @param text The changelog item text (may include markdown formatting).
+ * @param shape The corner shape for this item within a group or list.
+ * @param modifier The modifier to apply to this composable.
+ */
 @Composable
 fun ChangelogItem(
     text: String,
@@ -268,10 +275,11 @@ fun ChangelogItem(
 
         androidx.compose.foundation.layout.Row(
             modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.Top
         ) {
             Box(
                 modifier = Modifier
+                    .padding(top = 7.dp)
                     .size(6.dp)
                     .background(MaterialTheme.colorScheme.primary, RoundedCornerShape(50))
             )

--- a/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
@@ -1,30 +1,172 @@
 package echo.music.iad1tya.ui.utils
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
+import echo.music.iad1tya.echomusic.updater.ChangelogSection
 
-fun parseSimpleMarkdown(text: String): AnnotatedString {
+/**
+ * Parses markdown formatted text into an [AnnotatedString] supporting:
+ * - **bold**
+ * - *italic*
+ * - `inline code`
+ * - @mentions
+ * - [links](url)
+ */
+fun parseSimpleMarkdown(
+    text: String,
+    primaryColor: Color = Color.Unspecified
+): AnnotatedString {
+    // Strip leading bullet marker if the item itself starts with one
+    val cleanText = text.replace(Regex("^(?:[-*+•]|\\d+\\.)\\s+"), "")
+    val pattern = Regex(
+        "(\\*\\*(.*?)\\*\\*)|" +                     // 1, 2: **bold**
+        "(\\*([^*]+)\\*)|" +                         // 3, 4: *italic*
+        "(`([^`]+)`)|" +                             // 5, 6: `code`
+        "(@[a-zA-Z0-9_-]+)|" +                       // 7: @username
+        "(\\[([^\\]]+)\\]\\(([^)]+)\\))"             // 8, 9, 10: [text](url)
+    )
+
     return buildAnnotatedString {
-        val boldRegex = Regex("\\*\\*(.*?)\\*\\*")
-        var lastIndex = 0
+        var currentIndex = 0
+        val matches = pattern.findAll(cleanText)
 
-        val matches = boldRegex.findAll(text)
         for (match in matches) {
-            val normalText = text.substring(lastIndex, match.range.first)
-            append(normalText)
-            
-            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                append(match.groupValues[1])
+            if (match.range.first > currentIndex) {
+                append(cleanText.substring(currentIndex, match.range.first))
             }
-            
-            lastIndex = match.range.last + 1
+
+            when {
+                match.groups[1] != null -> { // **bold**
+                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(match.groups[2]!!.value)
+                    }
+                }
+                match.groups[3] != null -> { // *italic*
+                    withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
+                        append(match.groups[4]!!.value)
+                    }
+                }
+                match.groups[5] != null -> { // `code`
+                    withStyle(
+                        SpanStyle(
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Medium
+                        )
+                    ) {
+                        append(match.groups[6]!!.value)
+                    }
+                }
+                match.groups[7] != null -> { // @username
+                    withStyle(
+                        SpanStyle(
+                            fontWeight = FontWeight.SemiBold,
+                            color = if (primaryColor != Color.Unspecified) primaryColor else Color.Unspecified
+                        )
+                    ) {
+                        append(match.groups[7]!!.value)
+                    }
+                }
+                match.groups[8] != null -> { // [text](url)
+                    val linkText = match.groups[9]!!.value
+                    val linkUrl = match.groups[10]!!.value
+                    val startIndex = length
+                    withStyle(
+                        SpanStyle(
+                            color = if (primaryColor != Color.Unspecified) primaryColor else Color.Unspecified,
+                            textDecoration = TextDecoration.Underline
+                        )
+                    ) {
+                        append(linkText)
+                    }
+                    addStringAnnotation("URL", linkUrl, startIndex, length)
+                }
+            }
+            currentIndex = match.range.last + 1
         }
-        
-        if (lastIndex < text.length) {
-            append(text.substring(lastIndex))
+
+        if (currentIndex < cleanText.length) {
+            append(cleanText.substring(currentIndex))
         }
     }
 }
+
+/**
+ * Parses markdown release notes (such as those from GitHub Releases) into
+ * an optional introductory description and a list of structured [ChangelogSection]s.
+ */
+fun parseMarkdownToSections(markdown: String): Pair<String?, List<ChangelogSection>> {
+    if (markdown.isBlank()) return Pair(null, emptyList())
+
+    val lines = markdown.lines()
+    val sections = mutableListOf<ChangelogSection>()
+    val descriptionLines = mutableListOf<String>()
+
+    var currentSectionTitle: String? = null
+    val currentItems = mutableListOf<String>()
+
+    fun flushSection() {
+        val title = currentSectionTitle
+        if (title != null && currentItems.isNotEmpty()) {
+            sections.add(ChangelogSection(title, currentItems.toList()))
+            currentItems.clear()
+        }
+    }
+
+    for (rawLine in lines) {
+        val line = rawLine.trim()
+        if (line.isEmpty()) continue
+
+        // Ignore horizontal rules: --- or ***
+        if (line.matches(Regex("^-{3,}$|^\\*{3,}$|^_{3,}$"))) {
+            continue
+        }
+
+        // Ignore generic release footer links like "**Full Changelog**: https://..."
+        if (line.startsWith("**Full Changelog**", ignoreCase = true)) {
+            continue
+        }
+
+        // Headings: #, ##, ###, etc.
+        if (line.startsWith("#")) {
+            flushSection()
+            val cleanTitle = line.trimStart('#').trim()
+            currentSectionTitle = cleanTitle
+            continue
+        }
+
+        // Bullet list items: - , * , + , • or numbered list (e.g., "1. ")
+        val bulletMatch = Regex("^(?:[-*+•]|\\d+\\.)\\s+(.*)$").find(line)
+        if (bulletMatch != null) {
+            val itemContent = bulletMatch.groupValues[1].trim()
+            if (currentSectionTitle == null) {
+                currentSectionTitle = ""
+            }
+            currentItems.add(itemContent)
+            continue
+        }
+
+        // Ordinary non-bullet text
+        if (currentSectionTitle == null) {
+            descriptionLines.add(line)
+        } else if (currentItems.isNotEmpty()) {
+            // Continuation of the previous bullet item across multiple lines
+            val lastIdx = currentItems.size - 1
+            currentItems[lastIdx] = "${currentItems[lastIdx]} $line"
+        } else {
+            currentItems.add(line)
+        }
+    }
+
+    flushSection()
+
+    val description = descriptionLines.joinToString("\n").trim().takeIf { it.isNotEmpty() }
+    return Pair(description, sections)
+}
+

--- a/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
@@ -122,6 +122,7 @@ fun parseMarkdownToSections(markdown: String): Pair<String?, List<ChangelogSecti
 
     var currentSectionTitle: String? = null
     val currentItems = mutableListOf<String>()
+    var hadBlankLine = false
 
     fun flushSection() {
         val title = currentSectionTitle
@@ -133,24 +134,33 @@ fun parseMarkdownToSections(markdown: String): Pair<String?, List<ChangelogSecti
 
     for (rawLine in lines) {
         val line = rawLine.trim()
-        if (line.isEmpty()) continue
+        if (line.isEmpty()) {
+            hadBlankLine = true
+            if (currentSectionTitle == null && descriptionLines.isNotEmpty() && descriptionLines.last().isNotEmpty()) {
+                descriptionLines.add("")
+            }
+            continue
+        }
 
         // Ignore horizontal rules: --- or ***
         if (line.matches(Regex("^-{3,}$|^\\*{3,}$|^_{3,}$"))) {
+            hadBlankLine = true
             continue
         }
 
         // Ignore generic release footer links like "**Full Changelog**: https://..."
         if (line.startsWith("**Full Changelog**", ignoreCase = true)) {
+            hadBlankLine = true
             continue
         }
 
         // Headings: 1 to 6 '#' characters followed by whitespace (avoids matching issue references like #123)
-        val headingMatch = Regex("^#{1,6}\\s+(.+?)\\s*#*$").matchEntire(line)
+        val headingMatch = Regex("^#{1,6}\\s+(.+?)(?:\\s+#+)?\\s*$").matchEntire(line)
         if (headingMatch != null) {
             flushSection()
             val cleanTitle = headingMatch.groupValues[1].trim()
             currentSectionTitle = cleanTitle
+            hadBlankLine = false
             continue
         }
 
@@ -162,19 +172,22 @@ fun parseMarkdownToSections(markdown: String): Pair<String?, List<ChangelogSecti
                 currentSectionTitle = ""
             }
             currentItems.add(itemContent)
+            hadBlankLine = false
             continue
         }
 
         // Ordinary non-bullet text
+        val isIndented = rawLine.startsWith("  ") || rawLine.startsWith("\t")
         if (currentSectionTitle == null) {
             descriptionLines.add(line)
-        } else if (currentItems.isNotEmpty()) {
+        } else if (currentItems.isNotEmpty() && (!hadBlankLine || isIndented)) {
             // Continuation of the previous bullet item across multiple lines
             val lastIdx = currentItems.size - 1
             currentItems[lastIdx] = "${currentItems[lastIdx]} $line"
         } else {
             currentItems.add(line)
         }
+        hadBlankLine = false
     }
 
     flushSection()

--- a/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
@@ -2,22 +2,29 @@ package echo.music.iad1tya.ui.utils
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import echo.music.iad1tya.echomusic.updater.ChangelogSection
 
 /**
  * Parses markdown formatted text into an [AnnotatedString] supporting:
- * - **bold**
- * - *italic*
+ * - **bold** text
+ * - *italic* text
  * - `inline code`
- * - @mentions
- * - [links](url)
+ * - @mentions (styled with bold weight and optional accent color)
+ * - [links](url) (interactive clickable URLs via [LinkAnnotation.Url])
+ *
+ * @param text The markdown string to parse.
+ * @param primaryColor The accent color used for mentions and hyperlinks.
+ * @return An [AnnotatedString] ready for rendering in Compose [androidx.compose.material3.Text].
  */
 fun parseSimpleMarkdown(
     text: String,
@@ -76,16 +83,15 @@ fun parseSimpleMarkdown(
                 match.groups[8] != null -> { // [text](url)
                     val linkText = match.groups[9]!!.value
                     val linkUrl = match.groups[10]!!.value
-                    val startIndex = length
-                    withStyle(
-                        SpanStyle(
+                    val linkStyle = TextLinkStyles(
+                        style = SpanStyle(
                             color = if (primaryColor != Color.Unspecified) primaryColor else Color.Unspecified,
                             textDecoration = TextDecoration.Underline
                         )
-                    ) {
+                    )
+                    withLink(LinkAnnotation.Url(linkUrl, styles = linkStyle)) {
                         append(linkText)
                     }
-                    addStringAnnotation("URL", linkUrl, startIndex, length)
                 }
             }
             currentIndex = match.range.last + 1
@@ -100,6 +106,12 @@ fun parseSimpleMarkdown(
 /**
  * Parses markdown release notes (such as those from GitHub Releases) into
  * an optional introductory description and a list of structured [ChangelogSection]s.
+ *
+ * Headings (e.g. `## New Features`, `### Fixes`) become section titles, while list items
+ * (`- `, `* `, `+ `, `• `, `1. `) are grouped under their respective sections.
+ *
+ * @param markdown The raw release notes markdown text.
+ * @return A pair containing the optional description (preceding headings) and the list of sections.
  */
 fun parseMarkdownToSections(markdown: String): Pair<String?, List<ChangelogSection>> {
     if (markdown.isBlank()) return Pair(null, emptyList())
@@ -133,10 +145,11 @@ fun parseMarkdownToSections(markdown: String): Pair<String?, List<ChangelogSecti
             continue
         }
 
-        // Headings: #, ##, ###, etc.
-        if (line.startsWith("#")) {
+        // Headings: 1 to 6 '#' characters followed by whitespace (avoids matching issue references like #123)
+        val headingMatch = Regex("^#{1,6}\\s+(.+?)\\s*#*$").matchEntire(line)
+        if (headingMatch != null) {
             flushSection()
-            val cleanTitle = line.trimStart('#').trim()
+            val cleanTitle = headingMatch.groupValues[1].trim()
             currentSectionTitle = cleanTitle
             continue
         }
@@ -169,4 +182,5 @@ fun parseMarkdownToSections(markdown: String): Pair<String?, List<ChangelogSecti
     val description = descriptionLines.joinToString("\n").trim().takeIf { it.isNotEmpty() }
     return Pair(description, sections)
 }
+
 


### PR DESCRIPTION
### Summary of Changes
When an update is detected, the app displays the update dialog. Because GitHub releases publish release notes directly as Markdown in the release body rather than a standalone `changelog.json` asset, the updater fell back to reading the raw release body. Previously, `MarkdownParser` only parsed `**bold**` text and ignored headers, bullet markers, and mentions, causing raw Markdown syntax (`## New Features\n- ...`) to be displayed as unformatted text.

This PR fixes the issue by:
1. **Parsing Markdown into Sections**: Added `parseMarkdownToSections()` to convert Markdown headings (strictly matching `#{1,6}\s+` while preserving literal trailing hashes like `## C#`) and bullet points into structured `ChangelogSection` objects when `changelog.json` is not available. Also tracks blank lines to properly preserve distinct paragraphs.
2. **Enhanced Markdown Rendering**: Enhanced `parseSimpleMarkdown()` to format bold text, italics, inline code, clickable hyperlinks (`LinkAnnotation.Url`), and `@username` mentions, and to strip redundant leading bullet symbols.
3. **UI Polish**: In `UpdateAvailableDialog`, section headers are styled with bold primary typography, and bullet items use a custom `Row` layout with proper hanging indents so multiline items align cleanly.
4. **Consistency**: Applied the same parsing to `fetchChangelogForVersion()` and `WhatsNewDialog` so post-update changelogs render cleanly inside structured cards without duplicate description fallbacks.
5. **Card Bullet Alignment**: In `UpdaterComponents.kt`, updated `ChangelogItem` to top-align the bullet indicator with the first line of text, ensuring multiline changelog entries don't have awkwardly centered bullets.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX enhancement

### Screenshots

#### 1. Update Available Dialog
| Before (Raw Markdown) | After (Formatted Changelog) |
|:---:|:---:|
| <img width="1080" height="2400" alt="Before Update changelog" src="https://github.com/user-attachments/assets/191b9ae7-3d3a-43c9-9941-9502bd488a64" /> | <img width="1080" height="2400" alt="After Update changelog" src="https://github.com/user-attachments/assets/f41de016-df95-4cf9-ae24-8b9237f7db08" /> |

#### 2. What's New Dialog (Post-Update Pop-up)
| Before (Raw Markdown) | After (Formatted Changelog) |
|:---:|:---:|
| <img width="1080" height="2400" alt="Before Update Whatsnew" src="https://github.com/user-attachments/assets/349cc1b5-affa-4553-a4a1-d045fce80077" /> | <img width="1080" height="2400" alt="After Update Whatsnew" src="https://github.com/user-attachments/assets/bccb6c65-1247-440e-9f29-b63eb2e54346" /> |

### How Has This Been Tested?
1. Modified local version temporarily to trigger the update check against `v1.2.5`.
2. Verified `UpdateAvailableDialog` displays cleanly parsed sections ("New Features", "Fixes", "Improvements"), bold feature names, and styled bullets with proper hanging indents.
3. Tested post-update launch to verify `WhatsNewDialog` displays formatted changelog cards with top-aligned bullets on multiline entries.
4. Verified clickable links, strict heading regex matching (preserving literal `#`), and proper paragraph separation after blank lines.
5. Built successfully via `./gradlew assembleUniversalFossDebug`.
6. Reverted all test configurations.

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have tested my changes locally on a physical device.
- [x] I have included Before & After screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Update details support richer Markdown formatting, including bold, italic, inline code, mentions, and links.
  * Release notes are organized into headings with separate bullet or numbered items.
  * Changelogs and release descriptions can now appear together with clearer styling.
  * Multi-line entries, introductory descriptions, and footer links are displayed more clearly.

* **Bug Fixes**
  * Improved handling when structured changelog data is unavailable.
  * Blank section titles are no longer displayed, while plain descriptions remain visible when needed.
  * Markdown headings and separated paragraphs are interpreted more accurately.
  * Changelog bullet markers are aligned more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->