### PR TITLE
fix(ui): parse markdown changelog properly in update settings and dialogs

### DIFF
--- a/app/src/main/kotlin/com/music/echo/ui/component/UpdaterComponents.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/component/UpdaterComponents.kt
@@ -183,6 +183,12 @@ fun endItemShape(): RoundedCornerShape = RoundedCornerShape(
 
 fun detachedItemShape(): RoundedCornerShape = RoundedCornerShape(EndCornerRadius.dp)
 
+/**
+ * Parses markdown formatted text into an [androidx.compose.ui.text.AnnotatedString]
+ * supporting bold, italic, inline code, and interactive links with URL annotations.
+ *
+ * @return An [androidx.compose.ui.text.AnnotatedString] with formatted styles and link annotations.
+ */
 @Composable
 fun String.parseMarkdown(): androidx.compose.ui.text.AnnotatedString {
     val cleanText = this

--- a/app/src/main/kotlin/com/music/echo/ui/component/UpdaterComponents.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/component/UpdaterComponents.kt
@@ -185,6 +185,9 @@ fun detachedItemShape(): RoundedCornerShape = RoundedCornerShape(EndCornerRadius
 
 @Composable
 fun String.parseMarkdown(): androidx.compose.ui.text.AnnotatedString {
+    val cleanText = this
+        .replace(Regex("^(?:[-*+•]|\\d+\\.)\\s+"), "")
+        .replace(Regex("\\[\\[([^\\]]+)\\]\\(([^)]+)\\)\\](?:\\([^)]+\\))?"), "[$1]($2)")
     val builder = androidx.compose.ui.text.AnnotatedString.Builder()
     var currentIndex = 0
     val primaryColor = MaterialTheme.colorScheme.primary
@@ -192,10 +195,10 @@ fun String.parseMarkdown(): androidx.compose.ui.text.AnnotatedString {
     
     val pattern = Regex("(\\*\\*(.*?)\\*\\*)|(\\*([^*]+)\\*)|(`([^`]+)`)|(\\[([^\\]]+)\\]\\(([^)]+)\\))|((?:https?://|www\\.)[\\w-]+(?:\\.[\\w-]+)+(?:[/?][\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?)")
 
-    val matches = pattern.findAll(this)
+    val matches = pattern.findAll(cleanText)
     for (match in matches) {
         if (match.range.first > currentIndex) {
-            builder.append(this.substring(currentIndex, match.range.first))
+            builder.append(cleanText.substring(currentIndex, match.range.first))
         }
         
         when {
@@ -245,8 +248,8 @@ fun String.parseMarkdown(): androidx.compose.ui.text.AnnotatedString {
         currentIndex = match.range.last + 1
     }
     
-    if (currentIndex < this.length) {
-        builder.append(this.substring(currentIndex))
+    if (currentIndex < cleanText.length) {
+        builder.append(cleanText.substring(currentIndex))
     }
     
     return builder.toAnnotatedString()

--- a/app/src/main/kotlin/com/music/echo/ui/screens/settings/UpdateSettings.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/screens/settings/UpdateSettings.kt
@@ -62,6 +62,14 @@ import echo.music.iad1tya.ui.utils.parseSimpleMarkdown
 import echo.music.iad1tya.BuildConfig
 import org.json.JSONObject
 
+/**
+ * Settings screen for managing app updates, checking for new releases,
+ * and displaying the latest release notes ("What's New").
+ *
+ * @param navController Navigation controller for screen transitions.
+ * @param scrollBehavior Top app bar scroll behavior.
+ * @param highlightKey Optional key to highlight a specific settings item.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UpdateSettings(

--- a/app/src/main/kotlin/com/music/echo/ui/screens/settings/UpdateSettings.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/screens/settings/UpdateSettings.kt
@@ -54,6 +54,11 @@ import echo.music.iad1tya.echomusic.updater.getBetaUpdatesSetting
 import echo.music.iad1tya.echomusic.updater.saveBetaUpdatesSetting
 import echo.music.iad1tya.echomusic.updater.autoClearOldApks
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.text.font.FontWeight
+import echo.music.iad1tya.ui.utils.parseMarkdownToSections
+import echo.music.iad1tya.ui.utils.parseSimpleMarkdown
 import echo.music.iad1tya.BuildConfig
 import org.json.JSONObject
 
@@ -240,12 +245,70 @@ fun UpdateSettings(
                 ),
                 elevation = androidx.compose.material3.CardDefaults.cardElevation(defaultElevation = 0.dp)
             ) {
-                Text(
-                    text = echo.music.iad1tya.ui.utils.parseSimpleMarkdown(notes),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(20.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp)
+                ) {
+                    val (effectiveDescription, effectiveSections) = remember(notes) {
+                        parseMarkdownToSections(notes)
+                    }
+
+                    if (!effectiveDescription.isNullOrBlank()) {
+                        Text(
+                            text = parseSimpleMarkdown(effectiveDescription, MaterialTheme.colorScheme.primary),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                    }
+
+                    if (effectiveSections.isNotEmpty()) {
+                        effectiveSections.forEachIndexed { sectionIndex, section ->
+                            if (section.title.isNotBlank()) {
+                                Text(
+                                    text = parseSimpleMarkdown(section.title, MaterialTheme.colorScheme.primary),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.padding(
+                                        top = if (sectionIndex == 0 && effectiveDescription.isNullOrBlank()) 0.dp else 10.dp,
+                                        bottom = 4.dp
+                                    )
+                                )
+                            }
+                            section.items.forEach { item ->
+                                if (item.isNotBlank()) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 2.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        Text(
+                                            text = "•",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.primary,
+                                            fontWeight = FontWeight.Bold,
+                                        )
+                                        Text(
+                                            text = parseSimpleMarkdown(item.trim(), MaterialTheme.colorScheme.primary),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.weight(1f)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    } else if (effectiveDescription.isNullOrBlank()) {
+                        Text(
+                            text = parseSimpleMarkdown(notes, MaterialTheme.colorScheme.primary),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
             }
             Spacer(modifier = Modifier.height(16.dp))
         }

--- a/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
+++ b/app/src/main/kotlin/com/music/echo/ui/utils/MarkdownParser.kt
@@ -30,8 +30,10 @@ fun parseSimpleMarkdown(
     text: String,
     primaryColor: Color = Color.Unspecified
 ): AnnotatedString {
-    // Strip leading bullet marker if the item itself starts with one
-    val cleanText = text.replace(Regex("^(?:[-*+•]|\\d+\\.)\\s+"), "")
+    // Strip leading bullet marker if the item itself starts with one and normalize nested markdown links (e.g. GitHub release [[user](url)](url))
+    val cleanText = text
+        .replace(Regex("^(?:[-*+•]|\\d+\\.)\\s+"), "")
+        .replace(Regex("\\[\\[([^\\]]+)\\]\\(([^)]+)\\)\\](?:\\([^)]+\\))?"), "[$1]($2)")
     val pattern = Regex(
         "(\\*\\*(.*?)\\*\\*)|" +                     // 1, 2: **bold**
         "(\\*([^*]+)\\*)|" +                         // 3, 4: *italic*


### PR DESCRIPTION
### Summary of Changes
Recently, a "What's New" section was added to Update Settings to display the latest release notes. However, the raw release body was passed directly to a single `Text` composable, causing Markdown headings (`### `), bullet points (`- `), and contributor links to render as unformatted text. Additionally, GitHub's auto-generated contributor release notes use nested markdown links (`[[user](url)](url)`), which caused raw URLs and brackets to be displayed instead of clean clickable usernames across all changelogs.

This PR addresses both issues:
1. **Structured Changelog in Update Settings**: Connected `parseMarkdownToSections()` in `UpdateSettings.kt` to convert release notes into structured sections with bold primary headers (`titleSmall`) and hanging-indent bullet rows (`•`), matching `UpdateAvailableDialog`.
2. **Contributor Link Normalization**: Added normalization in `MarkdownParser.kt` and `UpdaterComponents.kt` to unpack GitHub's nested `[[username](url)](url)` into `[username](url)`, rendering clean, clickable contributor profile links without raw URL syntax.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX enhancement

### Screenshots

#### 1. Update Settings ("What's New" Section)
| Before (Raw Markdown) | After (Formatted Sections) |
|:---:|:---:|
| <img width="1080" height="2400" alt="Before update Update Settings screen" src="https://github.com/user-attachments/assets/de147458-86f0-433a-8b4c-16a54cef2dd7" /> | <img width="1080" height="2400" alt="After update Update Settings screen" src="https://github.com/user-attachments/assets/be206b6d-868b-4def-a8d8-10a3f85349f1" /> |

#### 2. Update Available Dialog (Contributors Links)
| Before (Raw URLs / Double Brackets) | After (Clean Clickable Links) |
|:---:|:---:|
| <img width="1080" height="2400" alt="Before update Update Available Dialog" src="https://github.com/user-attachments/assets/b077dac9-5bd1-4dc6-b28d-36575a1fc1bc" /> | <img width="1080" height="2400" alt="After update Update Available Dialog" src="https://github.com/user-attachments/assets/f13cdda9-f0d0-4172-8396-8160ffe34587" /> |

### How Has This Been Tested?
1. Tested on physical device.
2. Verified that **Settings → System Update → What's New** renders structured section titles ("New Features", "Improvements", "Bug Fixes", "Contributors") and bullet points.
3. Verified that contributor entries render as clean, styled, clickable links without raw Markdown brackets or URLs.

### Checklist
- [x] My code follows the code style and guidelines of this project.
- [x] I have tested my changes locally on a physical device.
- [x] I have included Before & After screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Release notes now display clearer descriptions, titled sections, bullet points, spacing, and structured styling.
  * Markdown formatting is handled more consistently for bold, italic, code, links, and mentions.
  * List markers and nested links are normalized for cleaner rendered text.
  * Unrecognized release note content continues to display as plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->